### PR TITLE
Use separate development tool installation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,19 +40,26 @@ jobs:
           key: "php-${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.json') }}"
           restore-keys: "php-${{ matrix.php-version }}-composer-"
 
+      - name: "Install development tools in highest version in a separate directory"
+        run: "mkdir /tmp/devtools && cp composer.json /tmp/devtools/ && cd /tmp/devtools/ && composer config name brainbits/devtools && composer update --prefer-dist --no-interaction --no-progress"
+
+      - name: "Install lowest version of thecodingmachine/safe in development tools for phpstan compatibility"
+        if: ${{ matrix.dependencies == 'lowest' }}
+        run: "cd /tmp/devtools/ && composer require 'thecodingmachine/safe' '^1.3'"
+
       - name: "Install lowest dependencies"
         if: ${{ matrix.dependencies == 'lowest' }}
-        run: "composer update --prefer-lowest --prefer-dist --no-interaction --no-progress --no-suggest"
+        run: "composer update --prefer-lowest --no-dev --prefer-dist --no-interaction --no-progress"
 
       - name: "Install highest dependencies"
         if: ${{ matrix.dependencies == 'highest' }}
-        run: "composer update --prefer-dist --no-interaction --no-progress --no-suggest"
+        run: "composer update --no-dev --prefer-dist --no-interaction --no-progress"
 
       - name: "Code Style"
-        run: "vendor/bin/phpcs"
+        run: "/tmp/devtools/vendor/bin/phpcs"
 
       - name: "Static Analysis"
-        run: "vendor/bin/phpstan analyze"
+        run: "/tmp/devtools/vendor/bin/phpstan analyze"
 
       - name: "Tests"
-        run: "vendor/bin/phpunit"
+        run: "/tmp/devtools/vendor/bin/phpunit"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
         php-version:
           - "8.1"
           - "8.2"
+          - "8.3"
 
     steps:
       - name: "Checkout"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -29,11 +29,11 @@ parameters:
             - RuntimeException
 
 includes:
-    - vendor/brainbits/phpstan-rules/rules.neon
-    - vendor/ergebnis/phpstan-rules/rules.neon
-    - vendor/jangregor/phpstan-prophecy/extension.neon
-    - vendor/phpstan/phpstan-phpunit/extension.neon
-    - vendor/phpstan/phpstan-phpunit/rules.neon
-    - vendor/phpstan/phpstan-symfony/extension.neon
-    - vendor/thecodingmachine/phpstan-safe-rule/phpstan-safe-rule.neon
-    - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon
+    - %rootDir%/../../brainbits/phpstan-rules/rules.neon
+    - %rootDir%/../../ergebnis/phpstan-rules/rules.neon
+    - %rootDir%/../../jangregor/phpstan-prophecy/extension.neon
+    - %rootDir%/../../phpstan/phpstan-phpunit/extension.neon
+    - %rootDir%/../../phpstan/phpstan-phpunit/rules.neon
+    - %rootDir%/../../phpstan/phpstan-symfony/extension.neon
+    - %rootDir%/../../thecodingmachine/phpstan-safe-rule/phpstan-safe-rule.neon
+    - %rootDir%/../../thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon

--- a/tests/Uuid/UuidTraitTest.php
+++ b/tests/Uuid/UuidTraitTest.php
@@ -97,7 +97,7 @@ final class UuidTraitTest extends TestCase
             self::fail('Expected ExpectationFailedException exception was not thrown');
         } catch (ExpectationFailedException $e) {
             self::assertSame(
-                'Failed asserting that \'foo\' is valid JSON (Syntax error, malformed JSON).',
+                'Failed asserting that a string is valid JSON (Syntax error, malformed JSON).',
                 $e->getMessage(),
             );
         } catch (Throwable) {


### PR DESCRIPTION
Stabilize the build process by always using the latest development tools, even if old dependencies are installed.