### PR TITLE
fix: Use attributes for after and before

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "phpstan/phpstan": "^1.2",
         "phpstan/phpstan-phpunit": "^1.0",
         "phpstan/phpstan-symfony": "^1.0",
-        "phpunit/phpunit": "^10.1",
+        "phpunit/phpunit": "^10.3",
         "riverline/multipart-parser": "^2.0",
         "slam/phpstan-extensions": "^6.0",
         "squizlabs/php_codesniffer": "^3.7.1",

--- a/src/Request/RequestTrait.php
+++ b/src/Request/RequestTrait.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Brainbits\FunctionalTestHelpers\Request;
 
+use PHPUnit\Framework\Attributes\After;
+use PHPUnit\Framework\Attributes\Before;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\BrowserKit\AbstractBrowser;
 use Symfony\Component\BrowserKit\Cookie;
@@ -29,13 +31,13 @@ trait RequestTrait
         return static fn () => null;
     }
 
-    /** @before */
+    #[Before]
     protected function setUpRequest(): void
     {
         self::$requestClient = static::createClient();
     }
 
-    /** @after */
+    #[After]
     protected function tearDownRequest(): void
     {
         self::$requestClient = null;

--- a/src/Snapshot/SnapshotTrait.php
+++ b/src/Snapshot/SnapshotTrait.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Brainbits\FunctionalTestHelpers\Snapshot;
 
 use DOMDocument;
+use PHPUnit\Framework\Attributes\Before;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use tidy;
@@ -40,7 +41,7 @@ trait SnapshotTrait
     /** @var array<string,int> */
     private array $filenames;
 
-    /** @before */
+    #[Before]
     final protected function setUpSnapshot(): void
     {
         $this->filenames = [];

--- a/src/Uuid/UuidTrait.php
+++ b/src/Uuid/UuidTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Brainbits\FunctionalTestHelpers\Uuid;
 
+use PHPUnit\Framework\Attributes\Before;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Uid\NilUuid;
 use Symfony\Component\Uid\Uuid;
@@ -21,7 +22,7 @@ trait UuidTrait
 {
     private int $lastUuidValue;
 
-    /** @before */
+    #[Before]
     final protected function setUpUuidTrait(): void
     {
         $this->lastUuidValue = 0;


### PR DESCRIPTION
BREAKING CHANGE: The functional test helpers now require phpunit 10.x+