### PR TITLE
fix(http-client-mock): add content-length to body

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "phpstan/phpstan-phpunit": "^1.0",
         "phpstan/phpstan-symfony": "^1.0",
         "phpunit/phpunit": "^11.4",
+        "psr/http-message": "^2.0",
         "riverline/multipart-parser": "^2.1",
         "slam/phpstan-extensions": "^6.0",
         "squizlabs/php_codesniffer": "^3.10",

--- a/src/HttpClientMock/MockRequestBuilderFactory.php
+++ b/src/HttpClientMock/MockRequestBuilderFactory.php
@@ -57,13 +57,14 @@ final class MockRequestBuilderFactory
         array $headers,
     ): void {
         $contentType = (string) $mockRequestBuilder->getHeader('Content-Type');
+        $contentLength = $mockRequestBuilder->getHeader('Content-Length') ?? 0;
 
         // application/json; charset=utf-8
         if (strpos($contentType, 'application/json') === 0) {
             if (is_string($body)) {
                 $mockRequestBuilder->json(json_decode($body, true));
             } elseif (is_callable($body)) {
-                $mockRequestBuilder->json(json_decode((string) $body(), true));
+                $mockRequestBuilder->json(json_decode((string) $body((int) $contentLength), true));
             } elseif (is_array($body)) {
                 $mockRequestBuilder->json($body);
             } else {

--- a/src/Request/RequestTrait.php
+++ b/src/Request/RequestTrait.php
@@ -20,6 +20,7 @@ use function sprintf;
 /** @mixin TestCase */
 trait RequestTrait
 {
+    /** @phpstan-ignore missingType.generics */
     private static AbstractBrowser|null $requestClient = null;
 
     protected function loginUser(): callable
@@ -44,6 +45,7 @@ trait RequestTrait
         self::$requestClient = null;
     }
 
+    /** @phpstan-ignore missingType.generics */
     protected static function getRequestClient(): AbstractBrowser
     {
         if (self::$requestClient) {

--- a/tests/HttpClientMock/MockRequestBuilderFactoryTest.php
+++ b/tests/HttpClientMock/MockRequestBuilderFactoryTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brainbits\FunctionalTestHelpers\Tests\HttpClientMock;
+
+use Brainbits\FunctionalTestHelpers\HttpClientMock\MockRequestBuilderFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\StreamInterface;
+
+#[CoversClass(MockRequestBuilderFactory::class)]
+final class MockRequestBuilderFactoryTest extends TestCase
+{
+    private readonly MockRequestBuilderFactory $mockRequestBuilderFactory;
+
+    public function setUp(): void
+    {
+        $this->mockRequestBuilderFactory = new MockRequestBuilderFactory();
+    }
+
+    public function testBuildsRequestWithoutBody(): void
+    {
+        $options = [
+            'headers' => ['Content-Type: application/json'],
+            'json' => ['foo' => 'bar'],
+        ];
+        $request = ($this->mockRequestBuilderFactory)('POST', 'https://service.com', $options);
+
+        self::assertSame('POST', $request->getMethod());
+        self::assertSame('https://service.com', $request->getUri());
+        self::assertSame(['foo' => 'bar'], $request->getJson());
+    }
+
+    public function testBuildsRequestWithJsonInBody(): void
+    {
+        $options = [
+            'headers' => [
+                'Content-Length: 1',
+                'Content-Type: application/json',
+            ],
+            'body' => '{"foo": "bar"}',
+        ];
+
+        $request = ($this->mockRequestBuilderFactory)('POST', 'https://service.com', $options);
+
+        self::assertSame('POST', $request->getMethod());
+        self::assertSame('https://service.com', $request->getUri());
+        self::assertSame(['foo' => 'bar'], $request->getJson());
+        self::assertTrue($request->isJson());
+    }
+
+    public function testBuildsRequestWithCallableInBody(): void
+    {
+        $body = $this->getMockBuilder(StreamInterface::class)->getMock();
+        $body->method('read')
+            ->willReturn('{"foo": "bar"}');
+
+        $options = [
+            'headers' => [
+                'Content-Length: 1',
+                'Content-Type: application/json',
+            ],
+            'body' => static fn (int $size) => $body->read($size),
+        ];
+
+        $request = ($this->mockRequestBuilderFactory)('POST', 'https://service.com', $options);
+
+        self::assertSame('POST', $request->getMethod());
+        self::assertSame('https://service.com', $request->getUri());
+        self::assertSame(['foo' => 'bar'], $request->getJson());
+        self::assertTrue($request->isJson());
+    }
+}


### PR DESCRIPTION
When mocking a request and the client’s bosy is a closure, the size parameter must be passed. The parameter is derived from the header `Content-Type`. 