### PR TITLE
fix: pass size to content cb in MockRequestBuilder

### DIFF
--- a/src/HttpClientMock/MockRequestBuilderFactory.php
+++ b/src/HttpClientMock/MockRequestBuilderFactory.php
@@ -132,7 +132,7 @@ final class MockRequestBuilderFactory
         }
 
         if (is_callable($body)) {
-            $mockRequestBuilder->content((string) $body());
+            $mockRequestBuilder->content((string) $body((int) $contentLength));
 
             return;
         }

--- a/tests/HttpClientMock/MockRequestBuilderFactoryTest.php
+++ b/tests/HttpClientMock/MockRequestBuilderFactoryTest.php
@@ -9,6 +9,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\StreamInterface;
 
+use function sprintf;
+
 #[CoversClass(MockRequestBuilderFactory::class)]
 final class MockRequestBuilderFactoryTest extends TestCase
 {
@@ -52,13 +54,17 @@ final class MockRequestBuilderFactoryTest extends TestCase
 
     public function testBuildsRequestWithCallableInBody(): void
     {
+        $size = 1;
         $body = $this->getMockBuilder(StreamInterface::class)->getMock();
-        $body->method('read')
+        $body
+            ->expects(self::once())
+            ->method('read')
+            ->with($size)
             ->willReturn('{"foo": "bar"}');
 
         $options = [
             'headers' => [
-                'Content-Length: 1',
+                sprintf('Content-Length: %d', $size),
                 'Content-Type: application/json',
             ],
             'body' => static fn (int $size) => $body->read($size),


### PR DESCRIPTION
Since the callback function expects a $size argument from symfony 7.2 onwards