### PR TITLE
feat(http-client-mock): add new method to reset request builder

### DIFF
--- a/src/HttpClientMock/MockRequestBuilderCollection.php
+++ b/src/HttpClientMock/MockRequestBuilderCollection.php
@@ -68,4 +68,9 @@ final class MockRequestBuilderCollection implements IteratorAggregate, Countable
     {
         return count($this->requestBuilders);
     }
+
+    public function reset(): void
+    {
+        $this->requestBuilders = [];
+    }
 }


### PR DESCRIPTION
The `$requestBuilders` array accumulated state across test runs with stale onMatch callbacks causing "Value of type null is not callable" errors.

This change introduces a `reset`-method to be called to reset the array.